### PR TITLE
incorrect langstring component

### DIFF
--- a/index.php
+++ b/index.php
@@ -44,7 +44,7 @@ if (!debugging() || empty($CFG->maintenance_enabled)) {
     $debugging = new moodle_url('/admin/settings.php', array('section' => 'debugging'));
     $maintenance = new moodle_url('/admin/settings.php', array('section' => 'maintenancemode'));
     $langparams = (object)array('debugging' => $debugging->out(false), 'maintenance' => $maintenance->out(false));
-    echo $OUTPUT->notification(get_string('nodebuggingmaintenancemode', 'local_anonymise', $langparams));
+    echo $OUTPUT->notification(get_string('nodebuggingmaintenancemode', 'local_pseudonymise', $langparams));
     echo $OUTPUT->footer();
     die();
 }


### PR DESCRIPTION
Your call to get_string for nodebuggingmaintenancemode refs local_anonymise rather than local_pseudonymise